### PR TITLE
Create CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# This is a CODEOWNERS file.
+# Lines starting with '#' are comments.
+
+# Define code owners for the infrastructure folder.
+# Only the specified users or teams can approve changes to this folder.
+/infrastructure/ @aaguiar @cosmicblackcat @danrpinho @lessthelonely
+
+# Protect the CODEOWNERS file itself
+/.github/CODEOWNERS @aaguiar @cosmicblackcat @danrpinho @lessthelonely


### PR DESCRIPTION

# Summary
This PR adds the `.github/` folder to the repository's root, which houses config files. Within this folder we find the `CODEOWNERS` file, which specifies code ownership rules for the repository.

# Context
The principle of **collective/shared code ownership** — originating from Extreme Programming (XP) [1] — advocates for equal responsibility and accountability among team members for all parts of the codebase. By adopting this practice, we aim to foster trust among team members while also promoting the dissemination of knowledge across the teams. This latter part helps with mitigating risks associated with the [Bus Factor](https://en.wikipedia.org/wiki/Bus_factor#Definition).

However, we are introducing the `CODEOWNERS` file to provide added oversight for the `infrastructure/` folder. This safeguard is coming into place to minimise breaking changes to our cloud infrastructure.

# Implementation Details
The `CODEOWNERS` file protects the `infrastructure/` folder by requiring a teacher to review any pull requests that involve changes to its contents. This protection does not restrict your ability to work on these files; instead, it ensures that your contributions are reviewed both by your peers and a teacher.

# References
[1] “Collective Ownership,” [www.extremeprogramming.org](http://www.extremeprogramming.org/). http://www.extremeprogramming.org/rules/collective.html
‌