### PR TITLE
fix: add DOCKER_BUILDKIT=1 to docker build command

### DIFF
--- a/infrastructure/pipeline/cloudbuild.yaml
+++ b/infrastructure/pipeline/cloudbuild.yaml
@@ -107,7 +107,7 @@ steps:
                   --project="${_PROJECT_ID}" > "${secret_file}"
 
                 echo "Building image for ${hero_name}..."
-                docker build --secret id=secret,src="${secret_file}" -t "${image_with_build_id}" "${dir}" || exit 1
+                DOCKER_BUILDKIT=1 docker build --secret id=secret,src="${secret_file}" -t "${image_with_build_id}" "${dir}" || exit 1
                 docker push "${image_with_build_id}" || exit 1
                 
                 rm -rf "${secret_file}"


### PR DESCRIPTION
This hopefully fixes the action failing.

According to [this](https://docs.docker.com/build/buildkit/#getting-started) it is just needed to have `DOCKER_BUILDKIT=1` for buildkit to be enabled.