### PR TITLE
Small fix in terraform file

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -635,7 +635,7 @@ resource "google_secret_manager_secret" "superhero_secrets" {
   }
 }
 
-resource "google_secret_manager_version" "superhero_secrets" {
+resource "google_secret_manager_secret_version" "superhero_secrets" {
   for_each = toset(local.superhero_names)
 
   secret_id = google_secret_manager_secret.superhero_secrets[each.key].id
@@ -666,11 +666,11 @@ resource "google_secret_manager_secret" "jarvis_secret" {
       replicas {
         location = "europe-west1"
       }
-    }
+    }   
   }
 }
 
-resource "google_secret_manager_version" "jarvis_secret" {
+resource "google_secret_manager_secret_version" "jarvis_secret" {
   secret_id = google_secret_manager_secret.jarvis_secret
   secret_data = "initial-secret-data for jarvis"
 }


### PR DESCRIPTION
Change all lines of google_secret_manager_version to google_secret_manager_secret_version, because of:
![image](https://github.com/user-attachments/assets/7dcada51-e851-48de-8ed6-7c705ea6b374)

[terraform documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_secret_version)

