### PR TITLE
Another small terraform fix

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -638,7 +638,7 @@ resource "google_secret_manager_secret" "superhero_secrets" {
 resource "google_secret_manager_secret_version" "superhero_secrets" {
   for_each = toset(local.superhero_names)
 
-  secret_id = google_secret_manager_secret.superhero_secrets[each.key].id
+  secret = google_secret_manager_secret.superhero_secrets[each.key].id
   secret_data = "initial-secret-data for superhero ${each.key}"
 }
 
@@ -671,7 +671,7 @@ resource "google_secret_manager_secret" "jarvis_secret" {
 }
 
 resource "google_secret_manager_secret_version" "jarvis_secret" {
-  secret_id = google_secret_manager_secret.jarvis_secret
+  secret = google_secret_manager_secret.jarvis_secret
   secret_data = "initial-secret-data for jarvis"
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/40cb6661-e78e-4b88-9563-0dbcb6aec2ee)

Again, it crashed on terraform, and taking a better look at the [terraform documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_secret_version) I provided in the last PR, the argument of google_secret_manager_secret_version resource should be secret and not secret_id. 