### PR TITLE
Enable secretmanager service

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -42,6 +42,7 @@ resource "google_project_service" "enable_services" {
     "compute.googleapis.com", 
     "cloudresourcemanager.googleapis.com",
     "iam.googleapis.com"
+    "secretmanager.googleapis.com"
   ])
   service = each.key
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0a1a2e1f-9f92-42ac-9119-e050fe3ff0b3)

It's not crashing anymore, but the secrets aren't being created yet. I came across this log in my service account page, so we need to enable this secretmanager service. Making progress maybe! :)