### PR TITLE
fix/whattheduck: wrong secret id in dockerfile

### DIFF
--- a/superheroes/superhero-08-01/Dockerfile
+++ b/superheroes/superhero-08-01/Dockerfile
@@ -6,9 +6,9 @@ COPY package*.json ./
 
 RUN npm install
 
-RUN --mount=type=secret,id=apikey \
-    if [ -f /run/secrets/apikey ]; then \
-        ENV_CONTENT=$(cat /run/secrets/apikey) && \
+RUN --mount=type=secret,id=secret \
+    if [ -f / ]; then \
+        ENV_CONTENT=$(cat /run/secrets/secret) && \
         echo -e "PROD=0\nPORT=3200\nGEMINI_API_KEY=${ENV_CONTENT}" > .env; \
     fi
 


### PR DESCRIPTION
Secret name was `apikey` and now it is to the same on as it is in the yaml in the pipeline