### PR TITLE
Changed backend URL to the cloud for superhero-01-03 (Req2Test)

### DIFF
--- a/avengers/frontend/webapp/src/app/assistants/req2test/api/api.js
+++ b/avengers/frontend/webapp/src/app/assistants/req2test/api/api.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const BASE_URL = 'http://localhost:8080';
+const BASE_URL = 'https://superhero-01-03-150699885662.europe-west1.run.app';
 
 export const getChats = async () => {
     const response = await axios.get(`${BASE_URL}/get_chats`);


### PR DESCRIPTION
Change the api call from localhost:8080 to the cloud URL for our superhero: https://superhero-01-03-150699885662.europe-west1.run.app