### PR TITLE
Feat/pass secret as docker build arg

### DIFF
--- a/infrastructure/pipeline/cloudbuild.yaml
+++ b/infrastructure/pipeline/cloudbuild.yaml
@@ -136,7 +136,6 @@ steps:
 
               if [ -f "${dockerfile}" ]; then
                 echo "Fetching secret for ${hero_name}..."
-                secret_file="/tmp/${hero_name}_secret"
 
                 superhero-secret=$(gcloud secrets versions access latest \
                   --secret="${hero_name}-secret" \

--- a/infrastructure/pipeline/cloudbuild.yaml
+++ b/infrastructure/pipeline/cloudbuild.yaml
@@ -138,12 +138,12 @@ steps:
                 echo "Fetching secret for ${hero_name}..."
                 secret_file="/tmp/${hero_name}_secret"
 
-                gcloud secrets versions access latest \
+                superhero-secret=$(gcloud secrets versions access latest \
                   --secret="${hero_name}-secret" \
-                  --project="${_PROJECT_ID}" > "${secret_file}"
+                  --project="${_PROJECT_ID}")
 
                 echo "Building image for ${hero_name}..."
-                if DOCKER_BUILDKIT=1 docker build --secret id=secret,src="${secret_file}" -t "${image_with_build_id}" "${dir}"; then
+                if docker build --build-arg GCLOUD_SECRET="${superhero-secret}" -t "${image_with_build_id}" "${dir}"; then
                   echo "Pushing image for ${hero_name}..."
                   docker push "${image_with_build_id}" || echo "Failed to push image for ${hero_name}. Skipping."
                 else


### PR DESCRIPTION
While building the docker image with `--secret` flag is the recommended way to build the docker image, no one seems to have been able to do it successfully. This PR uses a similar approach to the one used in the Jarvis build, in which at least a group managed to access the secret.