### PR TITLE
Revert "Feat/pass secret as docker build arg"

### DIFF
--- a/infrastructure/pipeline/cloudbuild.yaml
+++ b/infrastructure/pipeline/cloudbuild.yaml
@@ -132,13 +132,14 @@ steps:
 
               if [ -f "${dockerfile}" ]; then
                 echo "Fetching secret for ${hero_name}..."
+                secret_file="/tmp/${hero_name}_secret"
 
-                superhero-secret=$(gcloud secrets versions access latest \
+                gcloud secrets versions access latest \
                   --secret="${hero_name}-secret" \
-                  --project="${_PROJECT_ID}")
+                  --project="${_PROJECT_ID}" > "${secret_file}"
 
                 echo "Building image for ${hero_name}..."
-                if docker build --build-arg GCLOUD_SECRET="${superhero-secret}" -t "${image_with_build_id}" "${dir}"; then
+                if DOCKER_BUILDKIT=1 docker build --secret id=secret,src="${secret_file}" -t "${image_with_build_id}" "${dir}"; then
                   echo "Pushing image for ${hero_name}..."
                   docker push "${image_with_build_id}" || echo "Failed to push image for ${hero_name}. Skipping."
                 else


### PR DESCRIPTION
In light of new updates, which point to this solution not working, we have decided to go back to the previous solution which uses the recommended way of building a docker image with secrets.