### PR TITLE
Assistants/featurecraft/new c

### DIFF
--- a/avengers/frontend/webapp/src/app/assistants/featurecraft/components/messageBlock.js
+++ b/avengers/frontend/webapp/src/app/assistants/featurecraft/components/messageBlock.js
@@ -47,6 +47,7 @@ export default function MessageBlock({ messages, totalMessages, description, con
 
     const handleClosePopup = () => {
         setIsPopupVisible(false);
+        setSelectedText('');
     };
 
     const handlePinMessage = async () => {
@@ -162,21 +163,21 @@ export default function MessageBlock({ messages, totalMessages, description, con
             )}
             {isPopupVisible && (
                 <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-1">
-                    <div className="bg-white p-4 rounded-md shadow-md w-[50vw] h-[50vh] flex flex-col">
+                    <div className="bg-white p-4 rounded-xl shadow-md w-[50vw] h-[50vh] flex flex-col">
                         <textarea
-                            className="flex-grow p-2 border rounded-md"
+                            className="flex-grow p-2 border rounded-xl"
                             value={selectedText}
                             onChange={(e) => setSelectedText(e.target.value)}
                         />
                         <div className="mt-4 flex justify-center space-x-2">
                             <button
-                                className="bg-[#212529] text-white py-1 px-2 rounded-md w-32"
+                                className="bg-blue-100 text-grey py-1 px-2 rounded-xl w-32"
                                 onClick={handleClosePopup}
                             >
                                 Close
                             </button>
                             <button
-                                className="bg-[#6C757D] text-white py-1 px-2 rounded-md w-32"
+                                className="bg-blue-400 text-white py-1 px-2 rounded-xl w-32"
                                 onClick={handlePinMessage}
                             >
                                 Pin Message

--- a/avengers/frontend/webapp/src/app/assistants/featurecraft/components/messageBlock.js
+++ b/avengers/frontend/webapp/src/app/assistants/featurecraft/components/messageBlock.js
@@ -67,7 +67,12 @@ export default function MessageBlock({ messages, totalMessages, description, con
         const response = await deleteChat(conversationId, setError);
         setIsLoading(false);
         if (response) {
-            router.push('/assistants/featurecraft');
+            // If it is in ../assistants/featurecraft, reload the page
+            if (window.location.pathname === '/assistants/featurecraft') {
+                window.location.reload();
+            } else {
+                router.push('/assistants/featurecraft');
+            }
         }
     };
 

--- a/avengers/frontend/webapp/src/app/components/assistantMenu.js
+++ b/avengers/frontend/webapp/src/app/components/assistantMenu.js
@@ -12,6 +12,24 @@ export default function AssistantMenu({ buttons, assistantName }) {
         setShowSettings(!showSettings);
     };
 
+    if (assistantName === "FeatureCraft") {
+        return (
+            <div className="relative btn-group w-100 p-3 flex justify-center" role="group" aria-label="Basic example">
+                <a href="/assistants/featurecraft">
+                    <button
+                        type="button"
+                        data-placement="top"
+                        data-toggle="tooltip"
+                        title="New Conversation"
+                        className="btn btn-secondary w-12 h-12"
+                    >
+                        <i className={`bi bi-plus`}></i>
+                    </button>
+                </a>
+            </div>
+        );
+    }
+
     return (
         <div className="relative btn-group w-100 p-3" role="group" aria-label="Basic example">
             {buttons.map((button, index) => (


### PR DESCRIPTION
This pull request includes several changes to the `MessageBlock` and `AssistantMenu` components in the `avengers/frontend/webapp/src/app/assistants/featurecraft` directory. The most important changes include adding functionality to reload the page after deleting a chat, updating the styling of popups and buttons, and adding a new button for the "FeatureCraft" assistant.

Improvements to `MessageBlock` component:

* Added a condition to reload the page if the current path is `/assistants/featurecraft` after deleting a chat.
* Updated the styling of the popup and buttons to use rounded corners and new color schemes.
* Reset `selectedText` when closing the popup.

Enhancements to `AssistantMenu` component:

* Added a new button for the "FeatureCraft" assistant that links to `/assistants/featurecraft`.